### PR TITLE
Fixed RuntimeError: CUDA out of memory

### DIFF
--- a/lightweight_gan/lightweight_gan.py
+++ b/lightweight_gan/lightweight_gan.py
@@ -1065,7 +1065,7 @@ class Trainer():
         self.steps += 1
 
     @torch.no_grad()
-    def evaluate(self, num = 0, num_image_tiles = 8, trunc = 1.0):
+    def evaluate(self, num = 0, num_image_tiles = 4, trunc = 1.0):
         self.GAN.eval()
 
         ext = self.image_extension


### PR DESCRIPTION
When command run config use GPU memory pretty close to maximum the evaluate function throw error `RuntimeError: CUDA out of memory. Tried to allocate 772.00 MiB (GPU 0; 8.00 GiB total capacity; 3.18 GiB already allocated; 744.06 MiB free; 5.47 GiB reserved in total by PyTorch)`

```
Traceback (most recent call last):
  File "\anaconda3\envs\lgan\Scripts\lightweight_gan-script.py", line 33, in <module>
    sys.exit(load_entry_point('lightweight-gan', 'console_scripts', 'lightweight_gan')())
  File "e:\projects\lightweight-gan\lightweight-gan\lightweight_gan\cli.py", line 164, in main
    fire.Fire(train_from_folder)
  File "\anaconda3\envs\lgan\lib\site-packages\fire\core.py", line 138, in Fire
    component_trace = _Fire(component, args, parsed_flag_args, context, name)
  File "\anaconda3\envs\lgan\lib\site-packages\fire\core.py", line 468, in _Fire
    target=component.__name__)
  File "\anaconda3\envs\lgan\lib\site-packages\fire\core.py", line 672, in _CallAndUpdateTrace
    component = fn(*varargs, **kwargs)
  File "e:\projects\lightweight-gan\lightweight-gan\lightweight_gan\cli.py", line 155, in train_from_folder
    run_training(0, 1, model_args, data, load_from, new, num_train_steps, name, seed)
  File "e:\projects\lightweight-gan\lightweight-gan\lightweight_gan\cli.py", line 60, in run_training
    retry_call(model.train, tries=3, exceptions=NanException)
  File "\anaconda3\envs\lgan\lib\site-packages\retry\api.py", line 101, in retry_call
    return __retry_internal(partial(f, *args, **kwargs), exceptions, tries, delay, max_delay, backoff, jitter, logger)
  File "\anaconda3\envs\lgan\lib\site-packages\retry\api.py", line 33, in __retry_internal
    return f()
  File "e:\projects\lightweight-gan\lightweight-gan\lightweight_gan\lightweight_gan.py", line 1061, in train
    self.evaluate(floor(self.steps / self.evaluate_every))
  File "\anaconda3\envs\lgan\lib\site-packages\torch\autograd\grad_mode.py", line 26, in decorate_context
    return func(*args, **kwargs)
  File "e:\projects\lightweight-gan\lightweight-gan\lightweight_gan\lightweight_gan.py", line 1090, in evaluate
    torchvision.utils.save_image(generated_images, str(self.results_dir / self.name / f'{str(num)}.{ext}'), nrow=num_rows)
  File "\anaconda3\envs\lgan\lib\site-packages\torchvision\utils.py", line 128, in save_image
    ndarr = grid.mul(255).add_(0.5).clamp_(0, 255).permute(1, 2, 0).to('cpu', torch.uint8).numpy()
RuntimeError: CUDA out of memory. Tried to allocate 772.00 MiB (GPU 0; 8.00 GiB total capacity; 3.18 GiB already allocated; 744.06 MiB free; 5.47 GiB reserved in total by PyTorch)
```