### PR TITLE
Add zero-fills to progress output filenames, add sentence to README on how to convert to video

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ $ lightweight_gan \
   --num-image-tiles {count of image result}
 ```
 
-After run this command you will get folder near results image folder with postfix "-progress".
+After running this command you will get a new folder in the results folder, with postfix "-progress". You can convert the images to a video with ffmpeg using the command "ffmpeg -framerate 10 -pattern_type glob -i '*-ema.jpg' out.mp4".
 
 ![Show progress gif demonstration](./docs/show_progress/show-progress.gif)
 

--- a/lightweight_gan/lightweight_gan.py
+++ b/lightweight_gan/lightweight_gan.py
@@ -1209,6 +1209,8 @@ class Trainer():
         ext = self.image_extension
         latents = None
 
+        zfill_length = math.ceil(math.log10(len(checkpoints)))
+
         if not dir_full.exists():
             os.mkdir(dir_full)
 
@@ -1222,13 +1224,13 @@ class Trainer():
             # regular
             if 'default' in types:
                 generated_image = self.generate_(self.GAN.G, latents)
-                path = str(self.results_dir / dir_name / f'{str(checkpoint)}.{ext}')
+                path = str(self.results_dir / dir_name / f'{str(checkpoint).zfill(zfill_length)}.{ext}')
                 torchvision.utils.save_image(generated_image, path, nrow=num_images)
 
             # moving averages
             if 'ema' in types:
                 generated_image = self.generate_(self.GAN.GE, latents)
-                path = str(self.results_dir / dir_name / f'{str(checkpoint)}-ema.{ext}')
+                path = str(self.results_dir / dir_name / f'{str(checkpoint).zfill(zfill_length)}-ema.{ext}')
                 torchvision.utils.save_image(generated_image, path, nrow=num_images)
 
     @torch.no_grad()


### PR DESCRIPTION
This pull request fixes one minor problem and adds one sentence to the README:
1. The output filenames of the --show-progress flag are not zero-filled, making the progress images have wrong alphabetical order. This might cause problems when one tries to convert the images into a gif/video.
2. A sentence was added to the README on how to convert the images into a video.

Thanks for all the hard work!