### PR TITLE
Letting user generate sample/show progress without installing Aim

### DIFF
--- a/lightweight_gan/cli.py
+++ b/lightweight_gan/cli.py
@@ -151,6 +151,7 @@ def train_from_folder(
         calculate_fid_num_images = calculate_fid_num_images,
         clear_fid_cache = clear_fid_cache,
         amp = amp,
+        use_aim = use_aim,
         load_strict = load_strict
     )
 


### PR DESCRIPTION
## Additional information

Currently user who don't install Aim unable to generate sample or show progress without installing Aim. It's due to "model_args" doesn't carry value of args `--use-aim`[1] and default value of `use_aim` on Trainer class is `True`[2].

[1] https://github.com/lucidrains/lightweight-gan/blob/main/lightweight_gan/cli.py#L126
[2] https://github.com/lucidrains/lightweight-gan/blob/main/lightweight_gan/lightweight_gan.py#L983