### PR TITLE
Letting user generate sample/show progress without installing Aim

### DIFF
--- a/lightweight_gan/cli.py
+++ b/lightweight_gan/cli.py
@@ -155,7 +155,7 @@ def train_from_folder(
     )
 
     if generate:
-        model = Trainer(**model_args)
+        model = Trainer(**model_args, use_aim = use_aim)
         model.load(load_from)
         samples_name = timestamped_filename()
         checkpoint = model.checkpoint_num
@@ -164,7 +164,7 @@ def train_from_folder(
         return
 
     if generate_interpolation:
-        model = Trainer(**model_args)
+        model = Trainer(**model_args, use_aim = use_aim)
         model.load(load_from)
         samples_name = timestamped_filename()
         model.generate_interpolation(samples_name, num_image_tiles, num_steps = interpolation_num_steps, save_frames = save_frames)
@@ -172,7 +172,7 @@ def train_from_folder(
         return
 
     if show_progress:
-        model = Trainer(**model_args)
+        model = Trainer(**model_args, use_aim = use_aim)
         model.show_progress(num_images=num_image_tiles, types=generate_types)
         return
 


### PR DESCRIPTION
Currently user who don't install Aim unable to generate sample or show progress without installing Aim. It's due to "model_args" doesn't carry value of args `--use-aim`[1] and default value of `use_aim` on Trainer class is `True`[2]. I considered modifying dict "model_args" instead[3], but it cause error on different Trainer class initialization.

[1] https://github.com/lucidrains/lightweight-gan/blob/main/lightweight_gan/cli.py#L126
[2] https://github.com/lucidrains/lightweight-gan/blob/main/lightweight_gan/lightweight_gan.py#L983
[3] https://github.com/lucidrains/lightweight-gan/pull/136